### PR TITLE
Fix bounding box save failure and empty export in bronchoscopy task

### DIFF
--- a/bronchoscopy_boundingbox/static/bronchoscopy_boundingbox/bronchoscopy_boundingbox.js
+++ b/bronchoscopy_boundingbox/static/bronchoscopy_boundingbox/bronchoscopy_boundingbox.js
@@ -122,23 +122,31 @@ function removeBox(boxNr) {
     redrawSequence();
 }
 
+function clamp(v, lo, hi) {
+    return Math.max(lo, Math.min(v, hi));
+}
+
 function moveBox(boxNr, xDiff, yDiff) {
     var box = g_boxes[g_currentFrameNr][boxNr];
-    box.x += xDiff;
-    box.y += yDiff;
+    box.x = clamp(box.x + xDiff, 0, g_canvasWidth - box.width);
+    box.y = clamp(box.y + yDiff, 0, g_canvasHeight - box.height);
     redrawSequence();
 }
 
 function resizeBox(boxNr, xDiff, yDiff) {
     var box = g_boxes[g_currentFrameNr][boxNr];
     if (box.width > -xDiff + g_minimumSize)
-        box.width += xDiff;
+        box.width = clamp(box.width + xDiff, g_minimumSize, g_canvasWidth - box.x);
     if (box.height > -yDiff + g_minimumSize)
-        box.height += yDiff;
+        box.height = clamp(box.height + yDiff, g_minimumSize, g_canvasHeight - box.y);
     redrawSequence();
 }
 
 function createBox(x, y, x2, y2, label, color) {
+    x = clamp(x, 0, g_canvasWidth);
+    y = clamp(y, 0, g_canvasHeight);
+    x2 = clamp(x2, 0, g_canvasWidth);
+    y2 = clamp(y2, 0, g_canvasHeight);
     var originX = Math.min(x, x2);
     var originY = Math.min(y, y2);
     return {

--- a/exporters/bronchoscopy_boundingbox_exporter.py
+++ b/exporters/bronchoscopy_boundingbox_exporter.py
@@ -42,6 +42,11 @@ class BronchoscopyBoundingBoxExporter(Exporter):
 
         create_folder(path)
 
+        label_colors = {
+            label.name: '#%02x%02x%02x' % (label.color_red, label.color_green, label.color_blue)
+            for label in self.task.label.all()
+        }
+
         csv_path = join(path, 'annotations.csv')
         with open(csv_path, 'w', newline='') as csvfile:
             writer = csv.writer(csvfile)
@@ -66,7 +71,7 @@ class BronchoscopyBoundingBoxExporter(Exporter):
                             box.y,
                             box.width,
                             box.height,
-                            box.color,
+                            label_colors.get(box.label, ''),
                         ])
 
                     # Copy the annotated frame image


### PR DESCRIPTION
Clamp box coordinates to canvas bounds in moveBox/resizeBox/createBox so dragging or resizing a box past the edge can no longer send a negative x/y to the server, which was tripping the PositiveIntegerField CHECK constraint and rolling back the whole save.

Also fix the exporter, which still read the per-box `color` field removed in migration 0002; it crashed on the first row and left annotations.csv with only a header. Colors are now looked up from the task's Label objects instead.